### PR TITLE
Fix handling promise rejections

### DIFF
--- a/src/promiseproxy.js
+++ b/src/promiseproxy.js
@@ -26,7 +26,12 @@ function PromiseProxy(target, schema, self = PromiseProxy) {
       if (args[index] != null) {
         return Reflect.apply(method, receiver, args)
       }
-      return new Promise(resolve => Reflect.apply(method, receiver, insert(args, resolve, index)))
+      return new Promise((resolve, reject) => {
+        let executor = (err, returnValue) => {
+          err == null ? resolve(returnValue) : reject(err)
+        }
+        Reflect.apply(method, receiver, insert(args, executor, index))
+      })
     },
     get(target, key) {
       const prop = target[key]

--- a/test/promiseproxy.js
+++ b/test/promiseproxy.js
@@ -3,7 +3,7 @@
 const test = require('tape')
 const {PromiseProxy} = require('../')
 
-test('instatiate: with new', function (t) {
+test('promise api: resolve', function (t) {
   const schema = {
     tabs: {
       query: 1,
@@ -15,15 +15,50 @@ test('instatiate: with new', function (t) {
   const _chrome = {
     tabs: {
       query: (_, callback) => {
-        setTimeout(() => callback(n), 0)
-      },
-    },
+        setTimeout(() => callback(null, n), 0)
+      }
+    }
   }
 
   const pchrome = PromiseProxy(_chrome, schema)
 
-  pchrome.tabs.query({a: 1}).then((arg) => {
-    t.equal(arg, n)
-    t.end()
-  })
+  pchrome.tabs.query({a: 1})
+    .then((arg) => {
+      t.equal(arg, n)
+      t.end()
+    })
+    .catch((err) => {
+      t.notEqual(err, null)
+      t.fail('should not be rejected')
+      t.end()
+    })
+})
+
+test('promise api: reject', function (t) {
+  const schema = {
+    tabs: {
+      query: 1
+    }
+  }
+
+  // mock
+  const _chrome = {
+    tabs: {
+      query: (_, callback) => {
+        setTimeout(() => callback('error'), 0)
+      }
+    }
+  }
+
+  const pchrome = PromiseProxy(_chrome, schema)
+
+  pchrome.tabs.query({a: 1})
+    .then((arg) => {
+      t.fail('should not be resolved')
+      t.end()
+    })
+    .catch((err) => {
+      t.equal(err, 'error')
+      t.end()
+    })
 })


### PR DESCRIPTION
Using the [`promiseproxy-node`](https://github.com/slikts/promiseproxy-node) with node's `fs` module I noted that a _catch_ wouldn't be called on promise failures.

eg:

``` javascript
const PromiseProxyNode = require('promiseproxy-node')
const fs = PromiseProxyNode('fs')

fs.readFile('/not/existing/path')
  .then(data =>{
    // do stuff
  })
  .catch(err => {
    // handle error
  })
```

will pass an error as the data parameter
